### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/slopsauce/QRetro/security/code-scanning/1](https://github.com/slopsauce/QRetro/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the least privileges required for the workflow to function correctly. Since the workflow primarily involves checking out the repository, setting up Node.js, installing dependencies, and running build and linting commands, it only requires `contents: read` permissions. This ensures that the workflow can read the repository contents without granting unnecessary write access.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
